### PR TITLE
added live activity with glucose data.

### DIFF
--- a/DiaBLE.xcodeproj/project.pbxproj
+++ b/DiaBLE.xcodeproj/project.pbxproj
@@ -7,6 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		872AAF562AFE2571004698DE /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 872AAF552AFE2571004698DE /* WidgetKit.framework */; };
+		872AAF582AFE2571004698DE /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 872AAF572AFE2571004698DE /* SwiftUI.framework */; };
+		872AAF5B2AFE2572004698DE /* DiaBLE_LiveActivitiesBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872AAF5A2AFE2572004698DE /* DiaBLE_LiveActivitiesBundle.swift */; };
+		872AAF5D2AFE2572004698DE /* DiaBLE_LiveActivitiesLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872AAF5C2AFE2572004698DE /* DiaBLE_LiveActivitiesLiveActivity.swift */; };
+		872AAF5F2AFE2572004698DE /* DiaBLE_LiveActivities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872AAF5E2AFE2572004698DE /* DiaBLE_LiveActivities.swift */; };
+		872AAF612AFE2576004698DE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 872AAF602AFE2576004698DE /* Assets.xcassets */; };
+		872AAF652AFE2576004698DE /* DiaBLE_LiveActivitiesExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 872AAF542AFE2571004698DE /* DiaBLE_LiveActivitiesExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		87B377C92AFF3C2D00AC42CF /* DiaBLE_LiveActivitiesLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872AAF5C2AFE2572004698DE /* DiaBLE_LiveActivitiesLiveActivity.swift */; };
+		87B377CB2AFF3D2C00AC42CF /* WidgetCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B377CA2AFF3D2C00AC42CF /* WidgetCenter.swift */; };
 		C50B9AD32AA7396500FF1EA3 /* ConsoleTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50B9AD22AA7396500FF1EA3 /* ConsoleTools.swift */; };
 		C535AEB42AB3431F00AB61AD /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = C535AEB32AB3431F00AB61AD /* Realm */; };
 		C535AEB62AB3431F00AB61AD /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C535AEB52AB3431F00AB61AD /* RealmSwift */; };
@@ -90,6 +99,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		872AAF632AFE2576004698DE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C5AAA60D2981CF7000CA3EC1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 872AAF532AFE2571004698DE;
+			remoteInfo = DiaBLE_LiveActivitiesExtension;
+		};
 		C5BE8E5C29916D3600604237 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C5AAA60D2981CF7000CA3EC1 /* Project object */;
@@ -100,6 +116,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		872AAF6A2AFE2576004698DE /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				872AAF652AFE2576004698DE /* DiaBLE_LiveActivitiesExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C5BE8E5E29916D3600604237 /* Embed Watch Content */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -116,6 +143,16 @@
 /* Begin PBXFileReference section */
 		49DE8D3329AFFB3000BB7CF4 /* DiaBLE.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = DiaBLE.xcconfig; sourceTree = "<group>"; };
 		49DE8D3429AFFB3000BB7CF4 /* DiaBLEOverride.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = DiaBLEOverride.xcconfig; sourceTree = "<group>"; };
+		872AAF542AFE2571004698DE /* DiaBLE_LiveActivitiesExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DiaBLE_LiveActivitiesExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		872AAF552AFE2571004698DE /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		872AAF572AFE2571004698DE /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		872AAF5A2AFE2572004698DE /* DiaBLE_LiveActivitiesBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaBLE_LiveActivitiesBundle.swift; sourceTree = "<group>"; };
+		872AAF5C2AFE2572004698DE /* DiaBLE_LiveActivitiesLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaBLE_LiveActivitiesLiveActivity.swift; sourceTree = "<group>"; };
+		872AAF5E2AFE2572004698DE /* DiaBLE_LiveActivities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaBLE_LiveActivities.swift; sourceTree = "<group>"; };
+		872AAF602AFE2576004698DE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		872AAF622AFE2576004698DE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		872AAF662AFE2576004698DE /* DiaBLE_LiveActivitiesExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DiaBLE_LiveActivitiesExtension.entitlements; sourceTree = "<group>"; };
+		87B377CA2AFF3D2C00AC42CF /* WidgetCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetCenter.swift; sourceTree = "<group>"; };
 		C50B9AD22AA7396500FF1EA3 /* ConsoleTools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsoleTools.swift; sourceTree = "<group>"; };
 		C535AEB72AB343AE00AB61AD /* Realm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Realm.swift; sourceTree = "<group>"; };
 		C53F77C529894478004F275A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -175,6 +212,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		872AAF512AFE2571004698DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				872AAF582AFE2571004698DE /* SwiftUI.framework in Frameworks */,
+				872AAF562AFE2571004698DE /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C59960DC2981E381005999C2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -196,6 +242,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		872AAF592AFE2572004698DE /* DiaBLE_LiveActivities */ = {
+			isa = PBXGroup;
+			children = (
+				872AAF5A2AFE2572004698DE /* DiaBLE_LiveActivitiesBundle.swift */,
+				872AAF5C2AFE2572004698DE /* DiaBLE_LiveActivitiesLiveActivity.swift */,
+				872AAF5E2AFE2572004698DE /* DiaBLE_LiveActivities.swift */,
+				872AAF602AFE2576004698DE /* Assets.xcassets */,
+				872AAF622AFE2576004698DE /* Info.plist */,
+			);
+			path = DiaBLE_LiveActivities;
+			sourceTree = "<group>";
+		};
 		C5916E4529827E860051AC06 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -226,6 +284,7 @@
 		C5AAA60C2981CF7000CA3EC1 = {
 			isa = PBXGroup;
 			children = (
+				872AAF662AFE2576004698DE /* DiaBLE_LiveActivitiesExtension.entitlements */,
 				49DE8D3329AFFB3000BB7CF4 /* DiaBLE.xcconfig */,
 				49DE8D3429AFFB3000BB7CF4 /* DiaBLEOverride.xcconfig */,
 				C5E015DF2989B0EA00F6EDF9 /* README.md */,
@@ -233,6 +292,7 @@
 				C5E015E52989B10500F6EDF9 /* LICENSE.md */,
 				C5AAA6172981CF7000CA3EC1 /* DiaBLE */,
 				C59960E02981E381005999C2 /* DiaBLE Watch */,
+				872AAF592AFE2572004698DE /* DiaBLE_LiveActivities */,
 				C5AAA6162981CF7000CA3EC1 /* Products */,
 				C5BE8E5A29916D3600604237 /* Frameworks */,
 			);
@@ -243,6 +303,7 @@
 			children = (
 				C5AAA6152981CF7000CA3EC1 /* DiaBLE.app */,
 				C59960DF2981E381005999C2 /* DiaBLE Watch.app */,
+				872AAF542AFE2571004698DE /* DiaBLE_LiveActivitiesExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -255,6 +316,7 @@
 				C5E4006429825D1F0021C6B7 /* Extensions.swift */,
 				C5AAA6182981CF7000CA3EC1 /* App.swift */,
 				C5E4006729825DCD0021C6B7 /* Settings.swift */,
+				87B377CA2AFF3D2C00AC42CF /* WidgetCenter.swift */,
 				C5E4006A29825DDD0021C6B7 /* Bluetooth.swift */,
 				C5E4006D29825DEA0021C6B7 /* Device.swift */,
 				C5E4007029825DF50021C6B7 /* BluetoothDelegate.swift */,
@@ -284,6 +346,8 @@
 		C5BE8E5A29916D3600604237 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				872AAF552AFE2571004698DE /* WidgetKit.framework */,
+				872AAF572AFE2571004698DE /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -319,6 +383,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		872AAF532AFE2571004698DE /* DiaBLE_LiveActivitiesExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 872AAF672AFE2576004698DE /* Build configuration list for PBXNativeTarget "DiaBLE_LiveActivitiesExtension" */;
+			buildPhases = (
+				872AAF502AFE2571004698DE /* Sources */,
+				872AAF512AFE2571004698DE /* Frameworks */,
+				872AAF522AFE2571004698DE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DiaBLE_LiveActivitiesExtension;
+			productName = DiaBLE_LiveActivitiesExtension;
+			productReference = 872AAF542AFE2571004698DE /* DiaBLE_LiveActivitiesExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		C59960DE2981E381005999C2 /* DiaBLE Watch */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C59960EC2981E383005999C2 /* Build configuration list for PBXNativeTarget "DiaBLE Watch" */;
@@ -347,11 +428,13 @@
 				C5AAA6122981CF7000CA3EC1 /* Frameworks */,
 				C5AAA6132981CF7000CA3EC1 /* Resources */,
 				C5BE8E5E29916D3600604237 /* Embed Watch Content */,
+				872AAF6A2AFE2576004698DE /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				C5BE8E5D29916D3600604237 /* PBXTargetDependency */,
+				872AAF642AFE2576004698DE /* PBXTargetDependency */,
 			);
 			name = DiaBLE;
 			packageProductDependencies = (
@@ -370,9 +453,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1420;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
+					872AAF532AFE2571004698DE = {
+						CreatedOnToolsVersion = 15.0.1;
+					};
 					C59960DE2981E381005999C2 = {
 						CreatedOnToolsVersion = 14.2;
 					};
@@ -400,11 +486,20 @@
 			targets = (
 				C5AAA6142981CF7000CA3EC1 /* DiaBLE */,
 				C59960DE2981E381005999C2 /* DiaBLE Watch */,
+				872AAF532AFE2571004698DE /* DiaBLE_LiveActivitiesExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		872AAF522AFE2571004698DE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				872AAF612AFE2576004698DE /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C59960DD2981E381005999C2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -438,6 +533,16 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		872AAF502AFE2571004698DE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				872AAF5F2AFE2572004698DE /* DiaBLE_LiveActivities.swift in Sources */,
+				872AAF5D2AFE2572004698DE /* DiaBLE_LiveActivitiesLiveActivity.swift in Sources */,
+				872AAF5B2AFE2572004698DE /* DiaBLE_LiveActivitiesBundle.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C59960DB2981E381005999C2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -477,6 +582,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5E4008B29825EC40021C6B7 /* Events.swift in Sources */,
+				87B377C92AFF3C2D00AC42CF /* DiaBLE_LiveActivitiesLiveActivity.swift in Sources */,
+				87B377CB2AFF3D2C00AC42CF /* WidgetCenter.swift in Sources */,
 				C5E4005E29825C930021C6B7 /* Graph.swift in Sources */,
 				C5E4007929825E450021C6B7 /* Sensor.swift in Sources */,
 				C5E4009029825EEE0021C6B7 /* NFC.swift in Sources */,
@@ -514,6 +621,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		872AAF642AFE2576004698DE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 872AAF532AFE2571004698DE /* DiaBLE_LiveActivitiesExtension */;
+			targetProxy = 872AAF632AFE2576004698DE /* PBXContainerItemProxy */;
+		};
 		C5BE8E5D29916D3600604237 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			platformFilter = ios;
@@ -523,6 +635,72 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		872AAF682AFE2576004698DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = DiaBLE_LiveActivitiesExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3HJ6SH2W7S;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DiaBLE_LiveActivities/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = DiaBLE_LiveActivities;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.--TEAM-ID--.DiaBLEq.DiaBLE-LiveActivities";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		872AAF692AFE2576004698DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = DiaBLE_LiveActivitiesExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3HJ6SH2W7S;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DiaBLE_LiveActivities/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = DiaBLE_LiveActivities;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.--TEAM-ID--.DiaBLEq.DiaBLE-LiveActivities";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		C59960EA2981E383005999C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 49DE8D3329AFFB3000BB7CF4 /* DiaBLE.xcconfig */;
@@ -725,6 +903,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 49DE8D3329AFFB3000BB7CF4 /* DiaBLE.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = DiaBLE/DiaBLE.entitlements;
@@ -743,6 +922,7 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "DiaBLE reads blood glucose and insulin delivery data.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "DiaBLE tracks your blood glucose and saves the insulin delivery data.";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "DiaBLE reminds to check the glucose level at scheduled times.";
+				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -774,6 +954,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 49DE8D3329AFFB3000BB7CF4 /* DiaBLE.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = DiaBLE/DiaBLE.entitlements;
@@ -792,6 +973,7 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "DiaBLE reads blood glucose and insulin delivery data.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "DiaBLE tracks your blood glucose and saves the insulin delivery data.";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "DiaBLE reminds to check the glucose level at scheduled times.";
+				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -822,6 +1004,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		872AAF672AFE2576004698DE /* Build configuration list for PBXNativeTarget "DiaBLE_LiveActivitiesExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				872AAF682AFE2576004698DE /* Debug */,
+				872AAF692AFE2576004698DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C59960EC2981E383005999C2 /* Build configuration list for PBXNativeTarget "DiaBLE Watch" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/DiaBLE/Views/Graph.swift
+++ b/DiaBLE/Views/Graph.swift
@@ -1,6 +1,85 @@
 import Foundation
 import SwiftUI
 
+//struct LiveActivityGraph: View{
+//    
+//    var ymax: Double
+//    var settingsTargetHigh: Double
+//    var settingsTargetLow: Double
+//    
+//    var settingsTargetHighUnits: String
+//    var settingsTargetLowUnits: String
+//    
+//    var historyRawvaluesCount: Int
+//    var historyFactoryValuesCount: Int
+//    
+//    var yScale: Double
+//    var startingVoid: Bool
+//    var pathY: Int
+//    
+//    var body: some View{
+//        ZStack{
+//            GeometryReader { geometry in
+//                Path { path in
+//                    let width  = geometry.size.width - 60
+//                    let height = geometry.size.height
+//                    let yScale = (height - 20) / ymax
+//                    path.addRect(CGRect(x: 1 + 30, y: height - settingsTargetHigh * yScale + 1.0, width: width - 2, height: (settingsTargetHigh - settingsTargetLow) * yScale - 1))
+//                }.fill(Color.green).opacity(0.15)
+//            }
+//            
+//            GeometryReader { geometry in
+//                ZStack {
+//                    Text("\(settingsTargetHighUnits)")
+//                        .position(x: geometry.size.width - 15, y: geometry.size.height - (geometry.size.height - 20) / ymax * settingsTargetHigh)
+//                    Text("\(settingsTargetLowUnits)")
+//                        .position(x: geometry.size.width - 15, y: geometry.size.height - (geometry.size.height - 20) / ymax * settingsTargetLow)
+//                    let count = historyRawvaluesCount
+//                    if count > 0 {
+//                        let hours = count / 4
+//                        let minutes = count % 4 * 15
+//                        Text((hours > 0 ? "\(hours) h\n" : "") + (minutes != 0 ? "\(minutes) min" : ""))
+//                            .position(x: 5, y: geometry.size.height - geometry.size.height / 2)
+//                    } else { // factory data coming from LLU: TODO
+//                        let count = historyFactoryValuesCount
+//                        if count > 0 {
+//                            Text("12 h\n\n\(count) /\n144")
+//                                .position(x: 5, y: geometry.size.height - geometry.size.height / 2 - 8)
+//                        }
+//                    }
+//                }.font(.footnote).foregroundColor(.gray)
+//            }
+//            
+//            GeometryReader { geometry in
+//                let count = historyRawvaluesCount
+//                if count > 0 {
+//                    Path { path in
+//                        let width  = geometry.size.width - 60
+//                        let height = geometry.size.height
+//                        
+////                        let v = history.rawValues.map(\.value)
+//                        let xScale = width / Double(count - 1)
+//                        
+//                        if !startingVoid {
+//                            path.move(to: .init(x: 0 + 30, y: pathY))
+//                        }
+//                        for i in 1 ..< count {
+//                            if v[count - i - 1] > 0 {
+//                                let point = CGPoint(x: Double(i) * xScale + 30.0, y: height - Double(v[count - i - 1]) * yScale)
+//                                if !startingVoid {
+//                                    path.addLine(to: point)
+//                                } else {
+//                                    startingVoid = false
+//                                    path.move(to: point)
+//                                }
+//                            }
+//                        }
+//                    }.stroke(Color.yellow).opacity(0.6)
+//                }
+//            }
+//        }
+//    }
+//}
 
 struct Graph: View {
     @Environment(History.self) var history: History
@@ -8,6 +87,8 @@ struct Graph: View {
 
 
     func yMax() -> Double {
+        
+        
         let maxValues = [
             history.rawValues.map(\.value).max() ?? 0,
             history.factoryValues.map(\.value).max() ?? 0,
@@ -20,7 +101,7 @@ struct Graph: View {
 
     var body: some View {
         ZStack {
-
+            
             // Glucose range rect in the background
             GeometryReader { geometry in
                 Path { path in
@@ -34,6 +115,7 @@ struct Graph: View {
             // Target glucose low and high labels at the right, timespan on the left
             GeometryReader { geometry in
                 ZStack {
+//                    settings.targetHigh.uni
                     Text("\(settings.targetHigh.units)")
                         .position(x: geometry.size.width - 15, y: geometry.size.height - (geometry.size.height - 20) / yMax() * settings.targetHigh)
                     Text("\(settings.targetLow.units)")
@@ -147,4 +229,6 @@ struct Graph: View {
         .environment(Log())
         .environment(History.test)
         .environment(Settings())
+    
+//    LiveActivityGraph(ymax: 1, settingsTargetHigh: 3, settingsTargetLow: 1, settingsTargetHighUnits: "sthu", settingsTargetLowUnits: "stlu", historyRawvaluesCount: 12, historyFactoryValuesCount: 10)
 }

--- a/DiaBLE/Views/Monitor.swift
+++ b/DiaBLE/Views/Monitor.swift
@@ -72,6 +72,10 @@ struct Monitor: View {
 
                         }
 
+//                        app.glycemicAlarm.description   String
+//                        app.trendArrow.description    String
+//                        arrow Color   String
+                        
                         Text("\(app.glycemicAlarm.description.replacingOccurrences(of: "_", with: " "))\(app.glycemicAlarm.description != "" ? " - " : "")\(app.trendArrow.description.replacingOccurrences(of: "_", with: " "))")
                             .foregroundColor(app.currentGlucose > 0 && ((app.currentGlucose > Int(settings.alarmHigh) && (app.trendDelta > 0 || app.trendArrow == .rising || app.trendArrow == .risingQuickly)) || (app.currentGlucose < Int(settings.alarmLow) && (app.trendDelta < 0 || app.trendArrow == .falling || app.trendArrow == .fallingQuickly))) ?
                                 .red : .blue)

--- a/DiaBLE/Views/OnlineView.swift
+++ b/DiaBLE/Views/OnlineView.swift
@@ -32,9 +32,32 @@ struct OnlineView: View {
 
     @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State private var minuteTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+    
+    @StateObject var widgetController: WidgetCenter = .shared
 
 
     func reloadLibreLinkUp() async {
+        
+        print("reload function ############")
+//        start the live activity from here
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3){
+            if let sensor = app.sensor{
+                widgetController.startLiveActivity(
+                    lastReadingDate: app.lastReadingDate.shortTime,
+                    minuteSinceLastReading: "\(Int(Date().timeIntervalSince(app.lastReadingDate)/60))",
+                    currentGlucose: app.currentGlucose > 0 ? "\(app.currentGlucose.units) " : "--- ", alarmHigh: Int(settings.alarmHigh),
+                    alarmLow: Int(settings.alarmLow),
+                    color: app.currentGlucose > 0 && ((app.currentGlucose > Int(settings.alarmHigh) && (app.trendDelta > 0 || app.trendArrow == .rising || app.trendArrow == .risingQuickly)) || (app.currentGlucose < Int(settings.alarmLow) && (app.trendDelta < 0 || app.trendArrow == .falling || app.trendArrow == .fallingQuickly))) ? "red" : "blue", appState: app.status,
+                    sensorStateDescription: sensor.state.description, sensorStateColor: app.sensor.state == .active ? "green" : "red",
+                    glycemicAlarmDescription: app.glycemicAlarm.description,
+                    trendArrowDescription: app.trendArrow.description,
+                    arrowColor: app.currentGlucose > 0 && ((app.currentGlucose > Int(settings.alarmHigh) && (app.trendDelta > 0 || app.trendArrow == .rising || app.trendArrow == .risingQuickly)) || (app.currentGlucose < Int(settings.alarmLow) && (app.trendDelta < 0 || app.trendArrow == .falling || app.trendArrow == .fallingQuickly))) ?
+                    "red" : "blue")
+            }
+            
+        }
+        
+        
         if let libreLinkUp = await app.main?.libreLinkUp {
             var dataString = ""
             var retries = 0
@@ -306,6 +329,24 @@ struct OnlineView: View {
                                         if settings.onlineInterval > 0 && Int(Date().timeIntervalSince(settings.lastOnlineDate)) >= settings.onlineInterval * 60 - 5 {
                                             await reloadLibreLinkUp()
                                         }
+                                    }
+                                    
+                                
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 3){
+                                        if let sensor = app.sensor{
+                                            widgetController.updateLiveActivity(
+                                                lastReadingDate: app.lastReadingDate.shortTime,
+                                                minuteSinceLastReading: "\(Int(Date().timeIntervalSince(app.lastReadingDate)/60))",
+                                                currentGlucose: app.currentGlucose > 0 ? "\(app.currentGlucose.units) " : "--- ", alarmHigh: Int(settings.alarmHigh),
+                                                alarmLow: Int(settings.alarmLow),
+                                                color: app.currentGlucose > 0 && ((app.currentGlucose > Int(settings.alarmHigh) && (app.trendDelta > 0 || app.trendArrow == .rising || app.trendArrow == .risingQuickly)) || (app.currentGlucose < Int(settings.alarmLow) && (app.trendDelta < 0 || app.trendArrow == .falling || app.trendArrow == .fallingQuickly))) ? "red" : "blue", appState: app.status,
+                                                sensorStateDescription: sensor.state.description, sensorStateColor: app.sensor.state == .active ? "green" : "red",
+                                                glycemicAlarmDescription: app.glycemicAlarm.description,
+                                                trendArrowDescription: app.trendArrow.description,
+                                                arrowColor: app.currentGlucose > 0 && ((app.currentGlucose > Int(settings.alarmHigh) && (app.trendDelta > 0 || app.trendArrow == .rising || app.trendArrow == .risingQuickly)) || (app.currentGlucose < Int(settings.alarmLow) && (app.trendDelta < 0 || app.trendArrow == .falling || app.trendArrow == .fallingQuickly))) ?
+                                                "red" : "blue")
+                                        }
+                                        
                                     }
                                 }
 

--- a/DiaBLE/WidgetCenter.swift
+++ b/DiaBLE/WidgetCenter.swift
@@ -1,0 +1,74 @@
+//
+//  WidgetCenter.swift
+//  DiaBLE
+//
+//  Created by Anubhav Rawat on 11/11/23.
+//
+
+import ActivityKit
+import Foundation
+import SwiftUI
+
+class WidgetCenter: ObservableObject{
+    
+    static var shared = WidgetCenter()
+    
+    private init(){
+        
+    }
+    
+    var activity: Activity<DiaBLE_LiveActivitiesAttributes>? = nil
+
+    func startLiveActivity(lastReadingDate: String? = nil,  minuteSinceLastReading: String? = nil, currentGlucose: String, alarmHigh: Int, alarmLow: Int, color: String, appState: String, sensorStateDescription: String, sensorStateColor: String, glycemicAlarmDescription: String, trendArrowDescription: String, arrowColor: String){
+        
+        if activity != nil{
+            updateLiveActivity(lastReadingDate: lastReadingDate, minuteSinceLastReading: minuteSinceLastReading, currentGlucose: currentGlucose, alarmHigh: alarmHigh, alarmLow: alarmLow, color: color, appState: appState, sensorStateDescription: sensorStateDescription, sensorStateColor: sensorStateColor, glycemicAlarmDescription: glycemicAlarmDescription, trendArrowDescription: trendArrowDescription, arrowColor: arrowColor)
+            return
+        }
+        
+        print("starting live activity.")
+        
+        let attributes = DiaBLE_LiveActivitiesAttributes(name: "live activity")
+        
+        let state = ActivityContent(state: DiaBLE_LiveActivitiesAttributes.ContentState(lastReadingDate: lastReadingDate, minuteSinceLastReading: minuteSinceLastReading, currentGlucose: currentGlucose, alarmHigh: alarmHigh, alarmLow: alarmLow, color: color, appState: appState, sensorStateDescription: sensorStateDescription, sensorStateColor: sensorStateColor, glycemicAlarmDescription: glycemicAlarmDescription, trendArrowDescription: trendArrowDescription, arrowColor: arrowColor), staleDate: nil)
+        
+        activity = try?Activity.request(attributes: attributes, content: state)
+        
+    }
+    
+    //    var glycemicAlarmDescription: String
+    //    var trendArrowDescription: String
+    //    var arrowColor: String
+    func updateLiveActivity(lastReadingDate: String? = nil,  minuteSinceLastReading: String? = nil, currentGlucose: String, alarmHigh: Int, alarmLow: Int, color: String, appState: String, sensorStateDescription: String, sensorStateColor: String, glycemicAlarmDescription: String, trendArrowDescription: String, arrowColor: String){
+        
+        if activity == nil{
+            return
+        }
+        
+        print("updating live activity")
+         let state = ActivityContent(state: DiaBLE_LiveActivitiesAttributes.ContentState(lastReadingDate: lastReadingDate, minuteSinceLastReading: minuteSinceLastReading, currentGlucose: currentGlucose, alarmHigh: alarmHigh, alarmLow: alarmLow, color: color, appState: appState, sensorStateDescription: sensorStateDescription, sensorStateColor: sensorStateColor, glycemicAlarmDescription: glycemicAlarmDescription, trendArrowDescription: trendArrowDescription, arrowColor: arrowColor), staleDate: nil)
+        
+        Task{
+            await activity?.update(state)
+        }
+    }
+    
+     func observeActivity(){
+        
+        if let act = activity{
+            let activityState = act.activityState
+            if activityState == .dismissed{
+                activity = nil
+            }
+        }
+        
+//        Task{
+//            for await activityState in activity.activityStateUpdates{
+//                if activityState == .dismissed{
+//                    timer.invalidate()
+//                }
+//            }
+//        }
+    }
+    
+}

--- a/DiaBLE_LiveActivities/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/DiaBLE_LiveActivities/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DiaBLE_LiveActivities/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/DiaBLE_LiveActivities/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DiaBLE_LiveActivities/Assets.xcassets/Contents.json
+++ b/DiaBLE_LiveActivities/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DiaBLE_LiveActivities/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/DiaBLE_LiveActivities/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DiaBLE_LiveActivities/DiaBLE_LiveActivities.swift
+++ b/DiaBLE_LiveActivities/DiaBLE_LiveActivities.swift
@@ -1,0 +1,80 @@
+//
+//  DiaBLE_LiveActivities.swift
+//  DiaBLE_LiveActivities
+//
+//  Created by Anubhav Rawat on 10/11/23.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), emoji: "😀")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
+        let entry = SimpleEntry(date: Date(), emoji: "😀")
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, emoji: "😀")
+            entries.append(entry)
+        }
+
+        let timeline = Timeline(entries: entries, policy: .atEnd)
+        completion(timeline)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let emoji: String
+}
+
+struct DiaBLE_LiveActivitiesEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Emoji:")
+            Text(entry.emoji)
+        }
+    }
+}
+
+struct DiaBLE_LiveActivities: Widget {
+    let kind: String = "DiaBLE_LiveActivities"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            if #available(iOS 17.0, *) {
+                DiaBLE_LiveActivitiesEntryView(entry: entry)
+                    .containerBackground(.fill.tertiary, for: .widget)
+            } else {
+                DiaBLE_LiveActivitiesEntryView(entry: entry)
+                    .padding()
+                    .background()
+            }
+        }
+        .configurationDisplayName("My Widget")
+        .description("This is an example widget.")
+    }
+}
+
+#Preview(as: .systemSmall) {
+    DiaBLE_LiveActivities()
+} timeline: {
+    SimpleEntry(date: .now, emoji: "😀")
+    SimpleEntry(date: .now, emoji: "🤩")
+}

--- a/DiaBLE_LiveActivities/DiaBLE_LiveActivitiesBundle.swift
+++ b/DiaBLE_LiveActivities/DiaBLE_LiveActivitiesBundle.swift
@@ -1,0 +1,17 @@
+//
+//  DiaBLE_LiveActivitiesBundle.swift
+//  DiaBLE_LiveActivities
+//
+//  Created by Anubhav Rawat on 10/11/23.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct DiaBLE_LiveActivitiesBundle: WidgetBundle {
+    var body: some Widget {
+        DiaBLE_LiveActivities()
+        DiaBLE_LiveActivitiesLiveActivity()
+    }
+}

--- a/DiaBLE_LiveActivities/DiaBLE_LiveActivitiesLiveActivity.swift
+++ b/DiaBLE_LiveActivities/DiaBLE_LiveActivitiesLiveActivity.swift
@@ -1,0 +1,181 @@
+//
+//  DiaBLE_LiveActivitiesLiveActivity.swift
+//  DiaBLE_LiveActivities
+//
+//  Created by Anubhav Rawat on 10/11/23.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+
+
+struct DiaBLE_LiveActivitiesLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: DiaBLE_LiveActivitiesAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            HStack(spacing: 10){
+                VStack {
+                    if let lastReadingDate = context.state.lastReadingDate, let minuteSinceLastReading = context.state.minuteSinceLastReading{
+                        Text(lastReadingDate).monospacedDigit()
+                        Text(minuteSinceLastReading).font(.footnote).monospacedDigit()
+                    }else{
+                        Text("___")
+                    }
+                    
+    //                Text("Hello \(context.state.emoji)")
+                }
+                
+                HStack{
+                    Text(context.state.currentGlucose)
+                        .font(.system(size: 32, weight: .black))
+                        .foregroundStyle(.black)
+                        .padding(5)
+                        .background(context.state.color == "red" ? Color.red : Color.blue)
+                        .cornerRadius(8)
+                    
+                    Text("\(context.state.glycemicAlarmDescription.replacingOccurrences(of: "_", with: " "))\(context.state.glycemicAlarmDescription != "" ? " - " : "")\(context.state.trendArrowDescription.replacingOccurrences(of: "_", with: " "))")
+                        .foregroundStyle(context.state.arrowColor == "red" ? .red : .white)
+                }
+                
+                
+                VStack{
+                    Text(context.state.appState)
+                        .font(.footnote)
+                        .padding(.horizontal, 5)
+                    Text(context.state.sensorStateDescription)
+                        .foregroundStyle(context.state.sensorStateColor == "green" ? .green : .red)
+                }
+                
+            }
+            
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } 
+    dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    VStack {
+                        if let lastReadingDate = context.state.lastReadingDate, let minuteSinceLastReading = context.state.minuteSinceLastReading{
+                            Text(lastReadingDate).monospacedDigit()
+                            Text(minuteSinceLastReading).font(.footnote).monospacedDigit()
+                        }else{
+                            Text("___")
+                        }
+                        
+        //                Text("Hello \(context.state.emoji)")
+                    }
+                    
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    VStack{
+                        Text(context.state.appState)
+                            .font(.footnote)
+                            .padding(.horizontal, 5)
+                        Text(context.state.sensorStateDescription)
+                            .foregroundStyle(context.state.sensorStateColor == "green" ? .green : .red)
+                    }
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    // more content
+                    HStack{
+                        Text(context.state.currentGlucose)
+                            .font(.system(size: 32, weight: .black))
+                            .foregroundStyle(.black)
+                            .padding(5)
+                            .background(context.state.color == "red" ? Color.red : Color.blue)
+                            .cornerRadius(8)
+                        
+                        Text("\(context.state.glycemicAlarmDescription.replacingOccurrences(of: "_", with: " "))\(context.state.glycemicAlarmDescription != "" ? " - " : "")\(context.state.trendArrowDescription.replacingOccurrences(of: "_", with: " "))")
+                            .foregroundStyle(context.state.arrowColor == "red" ? .red : .white)
+                    }
+                }
+            } compactLeading: {
+                VStack{
+                    VStack {
+                        if let lastReadingDate = context.state.lastReadingDate, let minuteSinceLastReading = context.state.minuteSinceLastReading{
+                            Text(lastReadingDate).monospacedDigit()
+                                .font(.system(size: 10))
+                            Text(minuteSinceLastReading)
+                                .font(.system(size: 8))
+                                .monospacedDigit()
+                        }else{
+                            Text("___")
+                        }
+                        
+        //                Text("Hello \(context.state.emoji)")
+                    }
+                    
+                }
+            } compactTrailing: {
+//                Text("T \(context.state.emoji)")
+                ProgressView(value: 1){
+                    Text(context.state.currentGlucose)
+                        .font(.system(size: 10))
+                }
+                .progressViewStyle(.circular)
+                .tint(context.state.color == "red" ? Color.red : Color.blue)
+                
+            } minimal: {
+//                Text(context.state.emoji)
+                ProgressView(value: 1){
+                    Text(context.state.currentGlucose)
+                }
+                .progressViewStyle(.circular)
+                .tint(context.state.color == "red" ? Color.red : Color.blue)
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+ 
+struct DiaBLE_LiveActivitiesAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var lastReadingDate: String?
+        var minuteSinceLastReading: String?
+        var currentGlucose: String
+        var alarmHigh: Int
+        var alarmLow: Int
+        var color: String
+        
+        var appState: String
+        var sensorStateDescription: String
+        var sensorStateColor: String
+        
+        var glycemicAlarmDescription: String
+        var trendArrowDescription: String
+        var arrowColor: String
+    }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
+}
+
+extension DiaBLE_LiveActivitiesAttributes {
+    fileprivate static var preview: DiaBLE_LiveActivitiesAttributes {
+        DiaBLE_LiveActivitiesAttributes(name: "World")
+    }
+}
+
+//extension DiaBLE_LiveActivitiesAttributes.ContentState {
+//    fileprivate static var smiley: DiaBLE_LiveActivitiesAttributes.ContentState {
+//        DiaBLE_LiveActivitiesAttributes.ContentState(emoji: "😀")
+//     }
+//     
+//     fileprivate static var starEyes: DiaBLE_LiveActivitiesAttributes.ContentState {
+//         DiaBLE_LiveActivitiesAttributes.ContentState()
+//     }
+//}
+
+//#Preview("Notification", as: .content, using: DiaBLE_LiveActivitiesAttributes.preview) {
+//   DiaBLE_LiveActivitiesLiveActivity()
+//} contentStates: {
+//    DiaBLE_LiveActivitiesAttributes.ContentState.smiley
+//    DiaBLE_LiveActivitiesAttributes.ContentState.starEyes
+//}

--- a/DiaBLE_LiveActivities/Info.plist
+++ b/DiaBLE_LiveActivities/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/DiaBLE_LiveActivitiesExtension.entitlements
+++ b/DiaBLE_LiveActivitiesExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
I added the live activity with widget kit extension to show the glucose data. the live activity automatically starts reloadLibreLinkUp function. It also updates every 60 seconds. This live activity lasts for maximum of 8 hours for the dynamic island and 12 hours for the lock screen live activity. 
Let me know if you want any other minor change. 